### PR TITLE
Add PEP 708 to simple repository API

### DIFF
--- a/source/specifications/simple-repository-api.openapi.yml
+++ b/source/specifications/simple-repository-api.openapi.yml
@@ -91,7 +91,18 @@ paths:
                   - files
                 properties:
                   meta:
-                    $ref: '#/components/schemas/meta'
+                    allOf:
+                      - $ref: '#/components/schemas/meta'
+                      - title: Response metadata specific to project details
+                        type: object
+                        properties:
+                          tracks:
+                            title: Tracked projects URLs
+                            type: array
+                            items:
+                              title: Tracked project URL
+                              type: string
+                              format: uri
                   name:
                     title: Project name (normalised)
                     type: string

--- a/source/specifications/simple-repository-api.rst
+++ b/source/specifications/simple-repository-api.rst
@@ -282,6 +282,12 @@ A `metadata element`_ ``<meta>`` may exist anywhere in the HTML document, with
 ``content`` attribute value equal the API version which the response
 implements.
 
+Any number of `metadata element`_'s ``<meta>`` may exist anywhere in the HTML
+document, with ``name`` attribute value equal to the string ``pypi:tracks``,
+and ``content`` attribute value the URL to the project-details page in the
+package index which "owns" the project namespace (in essence, the source). *New
+in API v1.2.*
+
 Each distribution package file provided by the index for the project has a
 corresponding `anchor element`_ ``<a>``:
 
@@ -348,6 +354,12 @@ represents an object with properties:
 
   * ``api-version`` (string, required) - the API version the response
     implements.
+
+  * ``tracks`` (array of strings, optional) - the URLs to the project-details
+    page in the package indexes which "own" the project namespace (in essence,
+    the source).
+
+    *New in API v1.2*
 
 * ``name`` (string, required) - the :ref:`normalized <name-normalization>` name
   of the project.

--- a/source/specifications/simple-repository-api.rst
+++ b/source/specifications/simple-repository-api.rst
@@ -508,6 +508,8 @@ History
   choose between them, and declaring both formats as API v1, in :pep:`691`
 * October 2022: project versions and file size and upload-time in the JSON
   format, in :pep:`700`
+* February 2023: extends the API to mitigate dependency confusion attacks, in
+  :pep:`708`
 * June 2023: renaming the field which provides package metadata independently
   from a package, in :pep:`714`
 


### PR DESCRIPTION


<!-- readthedocs-preview python-packaging-user-guide start -->
----
:books: Documentation preview :books:: https://python-packaging-user-guide--3.org.readthedocs.build/en/3/

<!-- readthedocs-preview python-packaging-user-guide end -->